### PR TITLE
Issue #15: Added support for flask-restplus

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     ],
     extras_require={
         'dev': [
+            'flask-restplus',
             'flake8',
             'pytest',
             'pytest-flask',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ class OverloadBuzz(flask_buzz.FlaskBuzz):
 
 @pytest.fixture(scope='session')
 def app():
-    app = flask.Flask(__name__)
+    app = flask.Flask('normal_app')
     app.debug = False
     app.config['TESTING'] = True
     app.config['SERVER_NAME'] = 'test_server'
@@ -22,7 +22,13 @@ def app():
     def status():
         raise OverloadBuzz('status test')
 
-    app.register_error_handler(flask_buzz.FlaskBuzz, flask_buzz.error_handler)
+    app.register_error_handler(
+        flask_buzz.FlaskBuzz,
+        flask_buzz.build_error_handler(
+            lambda e: print('message: ', e.message),
+            lambda e: print('status_code: ', e.status_code),
+        ),
+    )
 
     with app.app_context():
         yield app

--- a/tests/test_flask_buzz.py
+++ b/tests/test_flask_buzz.py
@@ -43,9 +43,9 @@ class TestFlaskBuzz:
         response_json = json.loads(response.get_data(as_text=True))
         assert response_json['message'] == 'basic test'
 
-        captured = capsys.readouterr()
-        assert stripped('message: basic test') in stripped(captured.out)
-        assert stripped('status_code: 400') in stripped(captured.out)
+        (out, err) = capsys.readouterr()
+        assert stripped('message: basic test') in stripped(out)
+        assert stripped('status_code: 400') in stripped(out)
 
     def test_overloaded_status_code(self, app):
         """
@@ -85,6 +85,6 @@ class TestFlaskBuzz:
         assert response.status_code == 403
         assert response.json['message'] == 'restplus test'
 
-        captured = capsys.readouterr()
-        assert stripped('message: restplus test') in stripped(captured.out)
-        assert stripped('status_code: 403') in stripped(captured.out)
+        (out, err) = capsys.readouterr()
+        assert stripped('message: restplus test') in stripped(out)
+        assert stripped('status_code: 403') in stripped(out)

--- a/tests/test_flask_buzz.py
+++ b/tests/test_flask_buzz.py
@@ -1,7 +1,16 @@
 import flask
 import flask_buzz
+import flask_restplus
 import json
 import pytest
+import re
+
+
+def stripped(text):
+    """
+    Removes all whitespace from a string
+    """
+    return re.sub(r'\s+', '', text)
 
 
 class TestFlaskBuzz:
@@ -22,7 +31,7 @@ class TestFlaskBuzz:
         assert response.headers is not None
         assert response.status_code is not None
 
-    def test_basic_functionality(self, app):
+    def test_basic_functionality(self, app, capsys):
         """
         This test verifies that the basic functionality of FlaskBuzz works
         correctly. Verifies that the exception jsonifies correctly when it
@@ -33,6 +42,10 @@ class TestFlaskBuzz:
         assert response.status_code == flask_buzz.FlaskBuzz.status_code
         response_json = json.loads(response.get_data(as_text=True))
         assert response_json['message'] == 'basic test'
+
+        captured = capsys.readouterr()
+        assert stripped('message: basic test') in stripped(captured.out)
+        assert stripped('status_code: 400') in stripped(captured.out)
 
     def test_overloaded_status_code(self, app):
         """
@@ -45,3 +58,33 @@ class TestFlaskBuzz:
             assert response.status_code == 401
             response_json = json.loads(response.get_data(as_text=True))
             assert response_json['message'] == 'status test'
+
+    def test_flask_restplus_error_registration(self, app, capsys):
+        """
+        This test verifies that registration of FlaskBuzz error handlers in
+        Flask-Restplus works correctly
+        """
+        api = flask_restplus.Api(app)
+
+        class FRPError(flask_buzz.FlaskBuzz):
+            status_code = 403
+
+        @api.route('/restplus', endpoint='restplus')
+        class RestplusResource(flask_restplus.Resource):
+            def get(self):
+                raise FRPError('restplus test')
+
+        flask_buzz.register_error_handler_with_flask_restplus(
+            api,
+            lambda e: print('message: ', e.message),
+            lambda e: print('status_code: ', e.status_code),
+        )
+
+        client = app.test_client()
+        response = client.get(flask.url_for('restplus'))
+        assert response.status_code == 403
+        assert response.json['message'] == 'restplus test'
+
+        captured = capsys.readouterr()
+        assert stripped('message: restplus test') in stripped(captured.out)
+        assert stripped('status_code: 403') in stripped(captured.out)


### PR DESCRIPTION
Because flask-restplus does some different and strange things with its
error handler, I decided to add some sugar to make things easier. In
particular, the new register_error_handler_with_flask_restplus method
automatically registers error handlers for FlaskBuzz derived errors

Additionally, I deprecated the old error_handler method in favor of a
new build_error_handler method that can take a list of additional
functions that should be called with the error as the argument when the
error is handled. This is convenient if, say, your application needs to
log the error or other sorts of bookkeeping